### PR TITLE
Add reserved word "final" to be ignored, and a test

### DIFF
--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -253,7 +253,8 @@ reserved = {
     "_based":"IGNORE",
     "__stdcall":"IGNORE",
     "__try":"IGNORE",
-    "dllexport":"IGNORE"
+    "dllexport":"IGNORE",
+    "final":"IGNORE"
 
 }
 
@@ -1148,5 +1149,5 @@ def RunRules(ruleManager, lexer):
     except Exception, e:
         if nsiqcppstyle_state._nsiqcppstyle_state.verbose :
             print >> sys.stderr, "Rule Error : ", e       
-            traceback.print_exc(file=sys.stderr)     
+            traceback.print_exc(file=sys.stderr)
         

--- a/rules/RULE_3_2_F_use_representitive_classname_for_cpp_filename.py
+++ b/rules/RULE_3_2_F_use_representitive_classname_for_cpp_filename.py
@@ -159,3 +159,21 @@ class DLLEXPORT CCamRecorderFactory
 };
 """)
         assert not  CheckErrorContent(__name__) 
+
+    def test9(self):
+        self.Analyze("test/CamRecorderFactory.h",
+"""
+class CamRecorderFactory final
+{
+};
+""")
+        assert not CheckErrorContent(__name__)
+
+    def test10(self):
+        self.Analyze("test/CamRecorderFact.h",
+"""
+class CamRecorderFactory final
+{
+};
+""")
+        assert CheckErrorContent(__name__)


### PR DESCRIPTION
I have a class final that trigger RULE_3_2_F_use_representitive_classname_for_cpp_filename.py because it uses "final" as the class name, and not the real class name.

I added two tests to check that adding "final" to reserved words list corrects this rule, and ran all unit test.