### PR TITLE
Fixup template parsing

### DIFF
--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -578,19 +578,17 @@ class CppLexerNavigator(object):
             elif nextToken.type in ["GT"] :
                 tokenStack.pop()
                 if len(tokenStack) == 0 :
-                    return nextToken    
-                else :
-                    return None                
+                    return nextToken
             elif nextToken.type in ["RSHIFT"] :
                 tokenStack.pop()
+                if len(tokenStack) == 0 :
+                    return nextToken
                 tokenStack.pop()
                 if len(tokenStack) == 0 :
-                    return nextToken    
-                else :
-                    return None 
-                
-                
-            
+                    return nextToken
+
+
+
     def GetNextMatchingToken(self, keepCur = False):
         """
         Get matching token

--- a/rules/RULE_3_3_A_start_function_name_with_is_or_has_when_return_bool.py
+++ b/rules/RULE_3_3_A_start_function_name_with_is_or_has_when_return_bool.py
@@ -120,4 +120,30 @@ extern bool CTEST:canHave();
 boolean operator=();
 boolean KK::operator=();
 """)
-        assert not CheckErrorContent(__name__)    
+        assert not CheckErrorContent(__name__)
+    def test9(self):
+        self.Analyze("test/thisFile.c",
+"""
+template<class ObjectTypePtr,
+         typename = typename std::enable_if<std::is_pointer<ObjectTypePtr>::value>::type>
+bool canHave(ObjectTypePtr obj) {
+}
+
+template<class ObjectTypeNotPtr,
+         typename = typename std::enable_if<!std::is_pointer<ObjectTypeNotPtr>::value>::type>
+bool canHave(ObjectTypeNotPtr obj) {
+}""")
+        assert CheckErrorContent(__name__)
+    def test10(self):
+        self.Analyze("test/thisFile.c",
+"""
+template<class ObjectTypePtr,
+         typename = typename std::enable_if<std::is_pointer<ObjectTypePtr>::value>::type>
+bool isIt(ObjectTypePtr obj) {
+}
+
+template<class ObjectTypeNotPtr,
+         typename = typename std::enable_if<!std::is_pointer<ObjectTypeNotPtr>::value>::type>
+bool isIt(ObjectTypeNotPtr obj) {
+}""")
+        assert not CheckErrorContent(__name__)


### PR DESCRIPTION
While parsing templates, opening angle bracket where pushed each time it appened but only poped once.
If more than one opening angle bracket was found, 'None' was returned by the GetNextMatchingGT routine.

This commit pops the token until the queue is empty.
This type of template declaration was problematic:
   ```
   template<class ObjectTypePtr,
             typename = typename std::enable_if<std::is_pointer<ObjectTypePtr>::value>::type>
   ```