### PR TITLE
Fix misinterpretation of pointer to array as function declaration.

### DIFF
--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -1054,13 +1054,13 @@ def ContructContextInfo(lexer):
                 
                 if (t3 == None or t3.type != "NEW") and t2 != None and t2.type == "LPAREN" and (curContext == None or curContext.type in ["CLASS_BLOCK", "STRUCT_BLOCK", "NAMESPACE_BLOCK"]) and t4.type != "STRING":
                     # Check The ID after the next RPAREN
-                    # if there is ID or None it's not a function.
-                    # in case HELLO() HELLO2()
+                    # if there is ID, None, or LBRACKET it's not a function.
+                    # in case HELLO() HELLO2(), or FOO (BAR*)[]
                     lexer.PushTokenIndex()
                     lexer._MoveToToken(t2)
                     lexer.GetNextMatchingToken()
                     t5 = lexer.GetNextTokenSkipWhiteSpaceAndCommentAndPreprocess()
-                    if t5 == None or t5.type == "ID" :
+                    if t5 == None or t5.type in ["ID", "LBRACKET"] :
                         lexer.PopTokenIndex()
                         continue
                     lexer.PopTokenIndex()

--- a/nsiqunittest/nsiqcppstyle_unittest.py
+++ b/nsiqunittest/nsiqcppstyle_unittest.py
@@ -81,3 +81,12 @@ int a;
             tok = navigator.GetNextTokenSkipWhiteSpaceAndComment()
             if tok == None : break
             print tok, tok.contextStack, tok.pp
+    def test5(self):
+        data = """
+foo (bar*)[];
+"""
+        navigator = nsiqcppstyle_checker.CppLexerNavigator("a.cpp", data)
+        nsiqcppstyle_checker.ContructContextInfo(navigator)
+        navigator.Reset()
+        tok = navigator.GetNextTokenSkipWhiteSpaceAndComment()
+        assert(tok.type == 'ID' and tok.value == 'foo')


### PR DESCRIPTION
This fixes an issue that causes a definition of a pointer to an array to be misinterpreted as a function declaration. E.g. foo is interpreted as a function name in the statement "foor (*bar)[];"