### PR TITLE
nsiqcppstyle_exe: Restore indentation

### DIFF
--- a/nsiqcppstyle_exe.py
+++ b/nsiqcppstyle_exe.py
@@ -263,24 +263,24 @@ def main(argv=None):
                     ProcessFile(ruleManager, targetPath, analyzedFiles, ciMode)
 
             # if the target is directory, analyze it with filefilter and basefilelist
-        else:
-            for root, dirs, files in os.walk(targetPath):
-                if '.cvs' in dirs:
-                    dirs.remove('.cvs')
-                if '.svn' in dirs:
-                    dirs.remove('.svn')
-                if '.git' in dirs:
-                    dirs.remove('.git')
-                if '.hg' in dirs:
-                    dirs.remove('.hg')
-                for fname in files:
-                    fileExtension = fname[fname.rfind('.') + 1: ]
-                    eachFile = os.path.join(root, fname)
-                    basePart = eachFile[len(targetPath): ]
-                    if fileExtension in cExtendstionSet and basefilelist.IsNewOrChanged(eachFile) and filter.CheckFileInclusion(basePart):
-                        nsiqcppstyle_reporter.StartFile(os.path.dirname(basePart), fname)
-                        ProcessFile(ruleManager, eachFile, analyzedFiles, ciMode)
-                        nsiqcppstyle_reporter.EndFile()
+            else:
+                for root, dirs, files in os.walk(targetPath):
+                    if '.cvs' in dirs:
+                        dirs.remove('.cvs')
+                    if '.svn' in dirs:
+                        dirs.remove('.svn')
+                    if '.git' in dirs:
+                        dirs.remove('.git')
+                    if '.hg' in dirs:
+                        dirs.remove('.hg')
+                    for fname in files:
+                        fileExtension = fname[fname.rfind('.') + 1: ]
+                        eachFile = os.path.join(root, fname)
+                        basePart = eachFile[len(targetPath): ]
+                        if fileExtension in cExtendstionSet and basefilelist.IsNewOrChanged(eachFile) and filter.CheckFileInclusion(basePart):
+                            nsiqcppstyle_reporter.StartFile(os.path.dirname(basePart), fname)
+                            ProcessFile(ruleManager, eachFile, analyzedFiles, ciMode)
+                            nsiqcppstyle_reporter.EndFile()
             ruleManager.RunProjectRules(targetPath)
             nsiqcppstyle_reporter.EndTarget()
 


### PR DESCRIPTION
Restore proper indentation based on the code prior to this commit : kunaltyagi/nsiqcppstyle@f5767c1027915ab70f49524eec4d64a0f483474e

original: 
     https://github.com/kunaltyagi/nsiqcppstyle/blob/f5767c1027915ab70f49524eec4d64a0f483474e~1/nsiqcppstyle_exe.py#L260

fixes #12 
