### PR TITLE
Update lexer

### DIFF
--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -257,8 +257,9 @@ reserved = {
     "__stdcall": "IGNORE",
     "__try": "IGNORE",
     "dllexport": "IGNORE",
-    "final": "IGNORE"
-
+    "final": "IGNORE",
+    "override":"IGNORE",
+    "noexcept":"IGNORE"
 }
 
 

--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -579,7 +579,7 @@ class CppLexerNavigator(object):
         gtStack = []
         if self.GetCurToken().type != "LT":
             raise RuntimeError(
-                'Matching token should be examined when cur token is } ) ]')
+                'Matching next GT token should be examined when cur token is <')
         gtStack.append(self.GetCurToken())
         t = self._GetNextMatchingGTToken(gtStack)
         if keepCur:
@@ -686,6 +686,37 @@ class CppLexerNavigator(object):
                     continue
             if token.type not in context:
                 return token
+
+    def GetPrevMatchingLT(self, keepCur=False):
+        if keepCur :
+            self.PushTokenIndex()
+        gtStack = []
+        if not self.GetCurToken().type in ["GT", "RSHIFT"] :
+            raise RuntimeError(
+                'Matching previous LT token should be examined when cur token is > or >>')
+        # If >> token is found, append it twice
+        if self.GetCurToken().type == "RSHIFT" :
+            gtStack.append(self.GetCurToken())
+        gtStack.append(self.GetCurToken())
+        t = self._GetPrevMatchingLTToken(gtStack)
+        if keepCur :
+            self.PopTokenIndex()
+        return t
+
+    def _GetPrevMatchingLTToken(self, tokenStack):
+        while True :
+            prevToken = self._GetPrevToken()
+            if prevToken is None :
+                return None
+            elif prevToken.type in ["GT"] :
+                tokenStack.append(prevToken)
+            elif prevToken.type in ["RSHIFT"] :
+                tokenStack.append(prevToken)
+                tokenStack.append(prevToken)
+            elif prevToken.type in ["LT"] :
+                tokenStack.pop()
+                if len(tokenStack) == 0 :
+                    return prevToken
 
     def GetPrevMatchingToken(self, keepCur=False):
         if keepCur:

--- a/nsiqunittest/nsiqcppstyle_unittest.py
+++ b/nsiqunittest/nsiqcppstyle_unittest.py
@@ -30,8 +30,34 @@ import nsiqcppstyle_checker
 from nsiqcppstyle_outputer import _consoleOutputer as console
 import nsiqcppstyle_state
 
+class unitTest(unittest.TestCase):
+    def __testFunctionSpecifier(self, specifier):
+        lexer = nsiqcppstyle_checker.CppLexerNavigator("a.cpp", "void FunctionName() " + specifier + ";")
+        # This step resolves comments and some token types like FUNCTION
+        nsiqcppstyle_checker.ContructContextInfo(lexer)
+        lexer.Reset();
 
-class urlTest(unittest.TestCase):
+        assert(lexer.GetNextTokenSkipWhiteSpaceAndComment().type == 'VOID')
+        assert(lexer.GetNextTokenSkipWhiteSpaceAndComment().type == 'FUNCTION')
+        assert(lexer.GetNextTokenSkipWhiteSpaceAndComment().type == 'LPAREN')
+        assert(lexer.GetNextTokenSkipWhiteSpaceAndComment().type == 'RPAREN')
+        # Specifier keyword
+        specifierToken = lexer.GetNextTokenSkipWhiteSpaceAndComment()
+        assert(specifierToken.type == 'IGNORE')
+        assert(specifierToken.value == specifier)
+
+        assert(lexer.GetNextTokenSkipWhiteSpaceAndComment().type == 'SEMI')
+        assert(lexer.GetNextTokenSkipWhiteSpaceAndComment() == None)
+
+    def testIgnoreFinalFunctionSpecifier(self):
+        self.__testFunctionSpecifier("final")
+
+    def testIgnoreOverrideFunctionSpecifier(self):
+        self.__testFunctionSpecifier("override")
+
+    def testIgnoreNoexceptFunctionSpecifier(self):
+        self.__testFunctionSpecifier("noexcept")
+
     def test2(self):
         data = """
 #ifdef __NAME__
@@ -68,7 +94,7 @@ void function2() {
             tok = navigator.GetNextTokenSkipWhiteSpaceAndComment()
             if tok is None:
                 break
-            print tok, tok.contextStack
+            # print tok, tok.contextStack
 
     def test4(self):
         data = """
@@ -87,7 +113,7 @@ int a;
             tok = navigator.GetNextTokenSkipWhiteSpaceAndComment()
             if tok is None:
                 break
-            print tok, tok.contextStack, tok.pp
+            # print tok, tok.contextStack, tok.pp
 
     def test5(self):
         data = """


### PR DESCRIPTION
nsiqcppstyle_checker: Add some keywords to the lexer ignore list

The `override` and `noexcept` keywords break many rules (not detecting a function as a function)

For exemple, the line `void MoveRefFunction5(ANamespace::AType5&& message) override;`

Was interpreted as :
   - VOID ID LPAREN ID DOUBLECOLON ID LAND ID RPAREN ID SEMI

Instead of :
   - VOID FUNCTION LPAREN ID DOUBLECOLON ID LAND ID RPAREN OVERRIDE SEMI

As the OVERRIDE token does not exist in the lexer gramar, ignoring it results in :
   - VOID FUNCTION LPAREN ID DOUBLECOLON ID LAND ID RPAREN IGNORE SEMI

---

nsiqcppstyle_checker: Add GetPrevMatchingLT function to NSIQ lexer

Added GetNextMatchingGT counterpart function.
This function will return the matching opening '<' token for a '>' or '>>' one.