### PR TITLE
2019-10-23  Mark Galassi  <markgalassi@lanl.gov>

### DIFF
--- a/rules/RULE_10_1_A_do_not_use_bufferoverflow_risky_function_for_unix.py
+++ b/rules/RULE_10_1_A_do_not_use_bufferoverflow_risky_function_for_unix.py
@@ -42,6 +42,13 @@ def RunRule(lexer, contextStack):
             t2 = lexer.PeekNextTokenSkipWhiteSpaceAndComment()
             if t2 is not None and t2.type == "LPAREN":
                 t3 = lexer.PeekPrevTokenSkipWhiteSpaceAndComment()
+                # if :: comes first then we are not using dangerous C
+                # functions, so we can get out
+                if t3.type == "DOUBLECOLON":
+                    # check out the namespace that gives us this ::
+                    prev_namespace_token = lexer.GetPrevTokenInType("ID", keepCur=True)
+                    if prev_namespace_token.value != "std":
+                        return
                 if t3 is None or t3.type != "PERIOD":
                     nsiqcppstyle_reporter.Error(t, __name__,
                                                 "Do not use burfferoverflow risky function(%s)" % t.value)


### PR DESCRIPTION
* rules/RULE_10_1_A_do_not_use_bufferoverflow_risky_function_for_unix.py

(RunRule): added a check so that that these functions are only considered risky
if they are part of the std namespace, or have no namespace at all

/fixes #18 