### PR TITLE
Whitelist some implementations of dangerous C functions

### DIFF
--- a/rules/RULE_10_1_A_do_not_use_bufferoverflow_risky_function_for_unix.py
+++ b/rules/RULE_10_1_A_do_not_use_bufferoverflow_risky_function_for_unix.py
@@ -36,22 +36,42 @@ unix_bufferoverflow_functions = (
 
 
 def RunRule(lexer, contextStack):
+    # Boost.Format, Folly.Format don't provide printf but if they do,
+    # that can be handled by adding (or others) to whitelist
+    whitelist = ["fmt"]
+    blacklist = ["std", ""]  # to catch ::printf
+
     t = lexer.GetCurToken()
     if t.type == "ID":
         if t.value in unix_bufferoverflow_functions:
             t2 = lexer.PeekNextTokenSkipWhiteSpaceAndComment()
             if t2 is not None and t2.type == "LPAREN":
                 t3 = lexer.PeekPrevTokenSkipWhiteSpaceAndComment()
-                # if :: comes first then we are not using dangerous C
-                # functions, so we can get out
-                if t3.type == "DOUBLECOLON":
-                    # check out the namespace that gives us this ::
-                    prev_namespace_token = lexer.GetPrevTokenInType("ID", keepCur=True)
-                    if prev_namespace_token.value != "std":
-                        return
-                if t3 is None or t3.type != "PERIOD":
+                # tribool state: safe, unsafe, unknown
+                safe_alternative = False
+                unsafe_alternative = False
+                if t3 is None:
+                    # C style usage: flat out error
+                    unsafe_alternative = True
+                elif t3.type == "PERIOD":
+                    # class member: the call is safe, impl might not be
+                    safe_alternative = True
+                elif t3.type == "DOUBLECOLON":
+                    # check the namespace to classify as a dangerous
+                    # usage or a safe usage
+                    prev_namespace_token = lexer.GetPrevTokenInType(
+                        "ID", keepCur=True)
+                    if prev_namespace_token.value in whitelist:
+                        safe_alternative = True
+                    elif prev_namespace_token.value in blacklist:
+                        unsafe_alternative = True
+                    # elif unknown namespace => unknown safety
+                if unsafe_alternative:
                     nsiqcppstyle_reporter.Error(t, __name__,
-                                                "Do not use burfferoverflow risky function(%s)" % t.value)
+                                                "Do not use bufferoverflow risky function(%s)" % t.value)
+                elif not safe_alternative:
+                    nsiqcppstyle_reporter.Error(t, __name__,
+                                                "Caution: Uknown imlementation of a bufferoverflow risky function(%s)" % t.value)
 
 
 ruleManager.AddFunctionScopeRule(RunRule)
@@ -107,6 +127,58 @@ void strcat () {
 void func1()
 {
     k = help.strcat ()
+}
+""")
+        self.ExpectSuccess(__name__)
+
+    def test6(self):
+        self.Analyze("thisfile.c",
+                     """
+void func1()
+{
+    k = fmt::strcat ()
+}
+""")
+        self.ExpectSuccess(__name__)
+
+    def test7(self):
+        self.Analyze("thisfile.c",
+                     """
+void func1()
+{
+    k = std::strcat ()
+}
+""")
+        self.ExpectError(__name__)
+
+    def test8(self):
+        self.Analyze("thisfile.c",
+                     """
+void func1()
+{
+    k = random::strcat ()
+}
+""")
+        self.ExpectError(__name__)
+
+    def test8(self):
+        self.Analyze("thisfile.c",
+                     """
+void func1()
+{
+    k = ::strcat ()
+}
+""")
+        self.ExpectError(__name__)
+
+    def test9(self):
+        # known issue. Not a problem
+        self.Analyze("thisfile.c",
+                     """
+#define strcat k
+void func1()
+{
+    p = k()
 }
 """)
         self.ExpectSuccess(__name__)

--- a/rules/RULE_10_1_A_do_not_use_bufferoverflow_risky_function_for_unix.py
+++ b/rules/RULE_10_1_A_do_not_use_bufferoverflow_risky_function_for_unix.py
@@ -42,6 +42,13 @@ def RunRule(lexer, contextStack):
             t2 = lexer.PeekNextTokenSkipWhiteSpaceAndComment()
             if t2 is not None and t2.type == "LPAREN":
                 t3 = lexer.PeekPrevTokenSkipWhiteSpaceAndComment()
+                # if :: comes first then we are not using dangerous C
+                # functions, so we can get out
+                if t3.type == "DOUBLECOLON":
+                    # check out the namespace that gives us this ::
+                    prev_namespace_token = lexer.GetPrevTokenInType("ID", keepCur=True)
+                    if prev_namespace_token.value != "std":
+                        return
                 if t3 is None or t3.type != "PERIOD":
                     nsiqcppstyle_reporter.Error(t, __name__,
                                                 "Do not use burfferoverflow risky function(%s)" % t.value)


### PR DESCRIPTION
As reported in #19 and #18, some implementations provide a safe implementation, which need to be exempted.

Some tests have been added to track the changes

It will not break with C++20 at least.