### PR TITLE
Changes to port NsiqCppStyle from Python 2 to Python 3:

### DIFF
--- a/nsiqcppstyle.py
+++ b/nsiqcppstyle.py
@@ -47,9 +47,8 @@ def WeAreFrozen():
 
 def ModulePath():
     if WeAreFrozen():
-        return os.path.dirname(
-            unicode(sys.executable, sys.getfilesystemencoding()))
-    return os.path.dirname(unicode(__file__, sys.getfilesystemencoding()))
+        return os.path.dirname(sys.executable)
+    return os.path.dirname(__file__)
 
 
 def GetRuntimePath():

--- a/nsiqcppstyle.py
+++ b/nsiqcppstyle.py
@@ -27,39 +27,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-import sys
-import os
-import csv  # @UnusedImport
-import urllib  # @UnusedImport
+from nsiqcppstyle_util import *
 try:
     import hashlib  # @UnusedImport
 except ImportError:
     import md5  # @UnusedImport
-import unittest  # @UnusedImport
-import platform  # @UnusedImport
-import sre_compile  # @UnusedImport
-import shutil  # @UnusedImport
-
-
-def WeAreFrozen():
-    return hasattr(sys, "frozen")
-
-
-def ModulePath():
-    if WeAreFrozen():
-        return os.path.dirname(sys.executable)
-    return os.path.dirname(__file__)
-
-
-def GetRuntimePath():
-    "Return the path of this tool"
-    if (sys.platform == "win32"):
-        runtimePath = ModulePath()
-    else:
-        modename = globals()['__name__']
-        module = sys.modules[modename]
-        runtimePath = os.path.dirname(module.__file__)
-    return runtimePath
 
 
 if __name__ == "__main__":

--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -26,7 +26,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------
 
-import sys
 import os
 import traceback
 from nsiqcppstyle_outputer import _consoleOutputer as console

--- a/nsiqcppstyle_exe.py
+++ b/nsiqcppstyle_exe.py
@@ -38,11 +38,7 @@ import nsiqcppstyle_state
 import nsiqcppstyle_rulemanager
 import nsiqcppstyle_reporter
 import updateagent.agent
-from nsiqcppstyle_util import *  # @UnusedWildImport
-try:
-    set()
-except NameError:
-    from sets import Set as set
+from nsiqcppstyle_util import *
 
 version = "0.3.0.1"
 ##########################################################################
@@ -57,8 +53,7 @@ def ShowMessageAndExit(msg, usageOutput=True):
 
 
 def Usage():
-    print( \
-        """
+    print("""
 ======================================================================================
 Usage: nsiqcppstyle [Options]
            targetdirectory
@@ -307,7 +302,7 @@ def main(argv=None):
         return _nsiqcppstyle_state.error_count
 
     except Exception as err:
-        console.Err.Error(err.msg)
+        console.Err.Error(err)
         console.Err.Error("for help use --help")
         sys.exit(-1)
 
@@ -430,7 +425,7 @@ class FilterManager:
     def GetFilterFile(self, filterfile):
         if not os.path.exists(filterfile):
             return None
-        f = file(filterfile, 'r')
+        f = open(filterfile, 'r')
         return f
 
 ##############################################################################
@@ -585,7 +580,7 @@ class BaseFileList(object):
         if os.path.isdir(targetDir):
             fsrc = os.path.join(targetDir, "basefilelist.txt")
             if os.path.exists(fsrc):
-                f = file(fsrc)
+                f = open(fsrc)
                 for line in f.readlines():
                     self.baseFileList[line.strip()] = True
 

--- a/nsiqcppstyle_exe.py
+++ b/nsiqcppstyle_exe.py
@@ -44,7 +44,7 @@ try:
 except NameError:
     from sets import Set as set
 
-version = "0.2.2.13"
+version = "0.3.0.1"
 ##########################################################################
 title = "nsiqcppstyle: N'SIQ Cpp Style ver " + version + "\n"
 
@@ -57,7 +57,7 @@ def ShowMessageAndExit(msg, usageOutput=True):
 
 
 def Usage():
-    print \
+    print( \
         """
 ======================================================================================
 Usage: nsiqcppstyle [Options]
@@ -92,7 +92,7 @@ Usage: nsiqcppstyle [Options]
 
 * nsiqcppstyle reports coding standard violations on C/C++ source code.
 * In default, it doesn't apply any rules on the source. If you want to apply rule,
-  they are should be provided in the filefilter.txt file in following form.
+  they should be provided in the filefilter.txt file in following form.
   ~ RULENAME
 
 * You can customize the rule behavior by providing --var=key: value pair when executing
@@ -125,12 +125,13 @@ Usage: nsiqcppstyle [Options]
   And It checks only new and modified file. Please refer the nsiqcollector
   to generate basefilelist.txt.
 
-"""
+""")
     sys.exit(0)
 
 
 def main(argv=None):
     global filename
+
     if argv is None:
         argv = sys.argv
     try:
@@ -159,7 +160,7 @@ def main(argv=None):
         updateNsiqCppStyle = False
         for o, a in opts:
             if o in ("-h", "--help"):
-                print title
+                print(title)
                 Usage()
             elif o in ("-r", "--list-rules"):
                 ShowRuleList()
@@ -179,7 +180,7 @@ def main(argv=None):
                 _nsiqcppstyle_state.showUrl = True
             elif o == '--output':
                 if not a in ('emacs', 'vs7', 'csv', 'xml', 'eclipse'):
-                    print title
+                    print(title)
                     ShowMessageAndExit(
                         'The only allowed output formats are emacs, vs7 and csv.')
                 _nsiqcppstyle_state.output_format = a
@@ -305,7 +306,7 @@ def main(argv=None):
         nsiqcppstyle_reporter.CloseReport(_nsiqcppstyle_state.output_format)
         return _nsiqcppstyle_state.error_count
 
-    except Usage as err:
+    except Exception as err:
         console.Err.Error(err.msg)
         console.Err.Error("for help use --help")
         sys.exit(-1)
@@ -609,7 +610,7 @@ class NullBaseFileList(object):
 def ShowRuleList():
     nsiqcppstyle_rulemanager.ruleManager.availRuleNames.sort()
     for rule in nsiqcppstyle_rulemanager.ruleManager.availRuleNames:
-        print "~", rule
+        print("~", rule)
     sys.exit(1)
 
 

--- a/nsiqcppstyle_lexer.py
+++ b/nsiqcppstyle_lexer.py
@@ -35,28 +35,17 @@ __version__ = "3.2"
 __tabversion__ = "3.2"       # Version of table file used
 
 import re
-import sys
 import types
 import copy
-import os
+from nsiqcppstyle_util import *
 
 # This tuple contains known string types
-try:
-    # Python 2.6
-    StringTypes = (types.StringType, types.UnicodeType)
-except AttributeError:
-    # Python 3.0
-    StringTypes = (str, bytes)
+StringTypes = (str, bytes)
 
-# Extract the code attribute of a function. Different implementations
-# are for Python 2/3 compatibility.
+# Extract the code attribute of a function.
 
-if sys.version_info[0] < 3:
-    def func_code(f):
-        return f.func_code
-else:
-    def func_code(f):
-        return f.__code__
+def func_code(f):
+    return f.__code__
 
 # This regular expression is used to match valid token names
 _is_identifier = re.compile(r'^[a-zA-Z0-9_]+$')
@@ -755,8 +744,8 @@ class LexerReflect(object):
         # Sort the functions by line number
         for f in self.funcsym.values():
             if sys.version_info[0] < 3:
-                f.sort(lambda x, y: cmp(func_code(x[1]).co_firstlineno,
-                                        func_code(y[1]).co_firstlineno))
+                f.sort(lambda x, y: CmpObjects(func_code(x[1]).co_firstlineno,
+                                               func_code(y[1]).co_firstlineno))
             else:
                 # Python 3.0
                 f.sort(key=lambda x: func_code(x[1]).co_firstlineno)

--- a/nsiqcppstyle_reporter.py
+++ b/nsiqcppstyle_reporter.py
@@ -47,14 +47,14 @@ def PrepareReport(outputPath, format):
     if format == "csv":
         if os.path.isdir(outputPath):
             outputPath = os.path.join(outputPath, "nsiqcppstyle_report.csv")
-        csvfile = file(outputPath, "wb")
+        csvfile = open(outputPath, "wb")
         writer = csv.writer(csvfile)
         writer.writerow(("File", "Line", "Column",
                          "Message", "Rule", "Rule Url"))
     elif format == "xml":
         if os.path.isdir(outputPath):
             outputPath = os.path.join(outputPath, "nsiqcppstyle_report.xml")
-        writer = file(outputPath, "wb")
+        writer = open(outputPath, "wb")
         writer.write("<?xml version='1.0'?>\n<checkstyle version='4.4'>\n")
 
 

--- a/nsiqcppstyle_rulemanager.py
+++ b/nsiqcppstyle_rulemanager.py
@@ -248,9 +248,8 @@ class RollbackImporter:
         __builtins__["__import__"] = self._import
         self.newModules = {}
 
-    def _import(self, *args, **kwargs):
-        name = args[0]
-        result = self.realImport(*args, **kwargs)
+    def _import(self, name, *args, **kwargs):
+        result = self.realImport(name, *args, **kwargs)
         if name.find("rules") != -1:
             self.newModules[name] = 1
         return result

--- a/nsiqcppstyle_rulemanager.py
+++ b/nsiqcppstyle_rulemanager.py
@@ -248,8 +248,9 @@ class RollbackImporter:
         __builtins__["__import__"] = self._import
         self.newModules = {}
 
-    def _import(self, name, globals=None, locals=None, fromlist=[]):
-        result = self.realImport(*(name, globals, locals, fromlist))
+    def _import(self, *args, **kwargs):
+        name = args[0]
+        result = self.realImport(*args, **kwargs)
         if name.find("rules") != -1:
             self.newModules[name] = 1
         return result

--- a/nsiqcppstyle_util.py
+++ b/nsiqcppstyle_util.py
@@ -55,3 +55,7 @@ def GetSystemKey():
         return "window"
     else:
         return "linux"
+
+
+def CmpObjects(a, b):
+    return (a > b) - (a < b)

--- a/nsiqcppstyle_util.py
+++ b/nsiqcppstyle_util.py
@@ -35,9 +35,8 @@ def WeAreFrozen():
 
 def ModulePath():
     if WeAreFrozen():
-        return os.path.dirname(
-            unicode(sys.executable, sys.getfilesystemencoding()))
-    return os.path.dirname(unicode(__file__, sys.getfilesystemencoding()))
+        return os.path.dirname(sys.executable)
+    return os.path.dirname(__file__)
 
 
 def GetRuntimePath():

--- a/rules/RULE_3_2_F_use_representitive_classname_for_cpp_filename.py
+++ b/rules/RULE_3_2_F_use_representitive_classname_for_cpp_filename.py
@@ -37,13 +37,8 @@ If the class/struct name starts with "C", "C" can be ommited in the file name.
 """
 
 from nsiqunittest.nsiqcppstyle_unittestbase import *
-from nsiqcppstyle_rulemanager import *
 from nsiqcppstyle_reporter import *
 from nsiqcppstyle_rulemanager import *
-try:
-    set()
-except NameError:
-    from sets import Set as set
 
 classname = None
 

--- a/updateagent/agent.py
+++ b/updateagent/agent.py
@@ -1,8 +1,8 @@
 import re
-import string
 import nsiqcppstyle_util
 import os
 import urllib
+from nsiqcppstyle_util import *
 try:
     import hashlib
     md5_constructor = hashlib.md5
@@ -63,7 +63,7 @@ def Update(currentVersion):
 
             if os.path.exists(filestr):
                 checksum = md5_constructor()
-                f = file(filestr, 'rb').read()
+                f = open(filestr, 'rb').read()
                 checksum.update(f)
                 if agentFile["md5"] == checksum.hexdigest():
                     continue
@@ -106,7 +106,7 @@ def DownloadFile(url, agentFile, systemKey, recursed=False):
 
     checksum = md5_constructor()
 
-    f = file(downloadedFile[0], 'rb')
+    f = open(downloadedFile[0], 'rb')
     part = f.read()
     checksum.update(part)
     f.close()
@@ -154,4 +154,4 @@ class Version:
         if isinstance(other, str):
             other = Version(other)
 
-        return cmp(self.version, other.version)
+        return CmpObjects(self.version, other.version)

--- a/updateagent/agent.py
+++ b/updateagent/agent.py
@@ -1,6 +1,5 @@
 import re
 import string
-from types import StringType
 import nsiqcppstyle_util
 import os
 import urllib
@@ -20,8 +19,8 @@ def Update(currentVersion):
     systemKey = nsiqcppstyle_util.GetSystemKey()
     # Get the latest version info
     try:
-        print 'Update: checking for update'
-        print url + "/update/" + systemKey
+        print('Update: checking for update')
+        print(url + "/update/" + systemKey)
         request = urllib2.urlopen(url + "/update/" + systemKey)
         response = request.read()
     except urllib2.HTTPError as e:
@@ -44,11 +43,11 @@ def Update(currentVersion):
     try:
         updateInfo = updateagent.minjson.safeRead(response)
     except Exception as e:
-        print e
+        print(e)
         raise Exception('Unable to get latest version info. Try again later.')
 
     if Version(updateInfo['version']) > Version(currentVersion):
-        print 'A new version is available.'
+        print('A new version is available.')
 
         # Loop through the new files and call the download function
         for agentFile in updateInfo['files']:
@@ -71,7 +70,7 @@ def Update(currentVersion):
 
             agentFile['tempFile'] = DownloadFile(url, agentFile, systemKey)
             if agentFile['tempFile'] is None:
-                print "Update Failed while downloading : " + agentFile['name']
+                print("Update Failed while downloading : " + agentFile['name'])
                 return
             agentFile['new'] = True
         import shutil
@@ -84,7 +83,7 @@ def Update(currentVersion):
                     eachFileName.endswith(".exe")):
                 continue
             if agentFile.get('new', None) is not None:
-                print 'Updating ' + agentFile['name']
+                print('Updating ' + agentFile['name'])
                 newModule = os.path.join(runtimePath, agentFile['name'])
 
                 try:
@@ -101,7 +100,7 @@ def Update(currentVersion):
 
 
 def DownloadFile(url, agentFile, systemKey, recursed=False):
-    print 'Downloading ' + agentFile['name']
+    print('Downloading ' + agentFile['name'])
     downloadedFile = urllib.urlretrieve(url + '/update/' + systemKey +
                                         "/" + agentFile['name'])
 
@@ -119,7 +118,7 @@ def DownloadFile(url, agentFile, systemKey, recursed=False):
         if recursed == False:
             DownloadFile(url, agentFile, systemKey, True)
         else:
-            print agentFile['name'] + ' did not match its checksum - it is corrupted. This may be caused by network issues so please try again in a moment.'
+            print(agentFile['name'] + ' did not match its checksum - it is corrupted. This may be caused by network issues so please try again in a moment.')
             return None
 
 
@@ -152,7 +151,7 @@ class Version:
         return "LooseVersion ('%s')" % str(self)
 
     def __cmp__(self, other):
-        if isinstance(other, StringType):
+        if isinstance(other, str):
             other = Version(other)
 
         return cmp(self.version, other.version)


### PR DESCRIPTION
Closes #23 

(1) Modifying Python 2 functions and code style not compatible with Python 3, including adding parentheses to all "print" invocations
(2) Updating the version string from "0.2.2.13" to "0.3.0.1"
(3) Minor grammatical corrections
(4) Changing "except Usage" to "except Exception" (solved a thrown exception when Usage() function invoked internally)

This PR contains only modifications related to porting NsiqCppStyle from version 2 to 3.  Other modifications will follow in future PRs.