### PR TITLE
fix: remove binary keyword for opening xml/csv files

### DIFF
--- a/nsiqcppstyle_reporter.py
+++ b/nsiqcppstyle_reporter.py
@@ -47,14 +47,14 @@ def PrepareReport(outputPath, format):
     if format == "csv":
         if os.path.isdir(outputPath):
             outputPath = os.path.join(outputPath, "nsiqcppstyle_report.csv")
-        csvfile = open(outputPath, "wb")
+        csvfile = open(outputPath, "w")
         writer = csv.writer(csvfile)
         writer.writerow(("File", "Line", "Column",
                          "Message", "Rule", "Rule Url"))
     elif format == "xml":
         if os.path.isdir(outputPath):
             outputPath = os.path.join(outputPath, "nsiqcppstyle_report.xml")
-        writer = open(outputPath, "wb")
+        writer = open(outputPath, "w")
         writer.write("<?xml version='1.0'?>\n<checkstyle version='4.4'>\n")
 
 


### PR DESCRIPTION
Concerning https://github.com/kunaltyagi/nsiqcppstyle/issues/46