### PR TITLE
Add C++20 three-way comparison operator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: Tests CI
+
+on:
+    push:
+        branches: [ "master" ]
+    pull_request:
+        branches: [ "master" ]
+
+jobs:
+  Run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
+      - name: Run NSIQCppStyle tests
+        timeout-minutes: 5
+        run: PYTHONPATH=./:./rules python -m unittest discover -s nsiqunittest -p "*.py"
+
+      - name: Run NSIQCppStyle RULES tests
+        timeout-minutes: 5
+        run: PYTHONPATH=./:./rules python -m unittest discover -s rules -p "*.py"

--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -34,11 +34,11 @@ from nsiqcppstyle_rulehelper import *  # @UnusedWildImport
 
 tokens = [
     'ID',
-    # Operators (+,-,*,/,%,|,&,~,^,<<,>>, ||, &&, !, <, <=, >, >=, ==, !=)
+    # Operators (+,-,*,/,%,|,&,~,^,<<,>>, ||, &&, !, <, <=, >, >=, ==, !=, <=>)
     'PLUS', 'MINUS', 'TIMES', 'DIVIDE', 'MODULO',
     'OR', 'AND', 'NOT', 'XOR', 'LSHIFT', 'RSHIFT',
     'LOR', 'LAND', 'LNOT',
-    'LT', 'LE', 'GT', 'GE', 'EQ', 'NE',
+    'LT', 'LE', 'GT', 'GE', 'EQ', 'NE', 'SPACESHIP',
 
     # Assignment (=, *=, /=, %=, +=, -=, <<=, >>=, &=, ^=, |=)
     'EQUALS', 'TIMESEQUAL', 'DIVEQUAL', 'MODEQUAL', 'PLUSEQUAL', 'MINUSEQUAL',
@@ -135,6 +135,7 @@ t_LE = r'<='
 t_GE = r'>='
 t_EQ = r'=='
 t_NE = r'!='
+t_SPACESHIP = r'<=>'
 t_DOUBLECOLON = r'::'
 # Assignment operators
 
@@ -1244,7 +1245,7 @@ def RunRules(ruleManager, lexer):
                         ruleManager.RunFunctionScopeRule(lexer, t.contextStack)
                     elif sigContext.type in ["CLASS_BLOCK", "STRUCT_BLOCK", "ENUM_BLOCK", "NAMESPACE_BLOCK", "UNION_BLOCK"]:
                         ruleManager.RunTypeScopeRule(lexer, t.contextStack)
-                
+
                 ruleManager.RunRule(lexer, t.contextStack)
         except Exception as e:
             console.Err.Verbose("Rule Error : ", t, t.contextStack, e)

--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -1236,7 +1236,7 @@ def RunRules(ruleManager, lexer):
                 elif t.type == "FUNCTION":
                     ruleManager.RunFunctionNameRule(lexer, t.fullName, t.decl,
                                                     t.contextStack, t.context)
-                elif t.type in ["COMMENT", "CPPCOMMENT"]:
+                elif t.type in ("COMMENT", "CPPCOMMENT"):
                     ruleManager.RunCommentRule(lexer, t)
                     continue
                 elif t.contextStack is not None and t.contextStack.SigPeek() is not None:

--- a/nsiqcppstyle_checker.py
+++ b/nsiqcppstyle_checker.py
@@ -1230,13 +1230,13 @@ def RunRules(ruleManager, lexer):
             if t.pp == True:
                 ruleManager.RunPreprocessRule(lexer, t.contextStack)
             else:
-                if t.type == 'TYPE':
+                if t.type == "TYPE":
                     ruleManager.RunTypeNameRule(lexer, t.value.upper(), t.fullName,
                                                 t.decl, t.contextStack, t.context)
-                elif t.type == 'FUNCTION':
+                elif t.type == "FUNCTION":
                     ruleManager.RunFunctionNameRule(lexer, t.fullName, t.decl,
                                                     t.contextStack, t.context)
-                elif ((t.type == 'COMMENT') or (t.type == 'CPPCOMMENT')):
+                elif t.type in ["COMMENT", "CPPCOMMENT"]:
                     ruleManager.RunCommentRule(lexer, t)
                     continue
                 elif t.contextStack is not None and t.contextStack.SigPeek() is not None:

--- a/rules/RULE_4_1_A_A_use_tab_for_indentation.py
+++ b/rules/RULE_4_1_A_A_use_tab_for_indentation.py
@@ -1,6 +1,6 @@
 """
 Use tabs for indentation.
-This rule check if the each line starts with a space.
+This rule ensures that each line starts with tabs.
 In addition, it suppresses the violation when the line contains only spaces and tabs.
 
 == Violation ==
@@ -25,6 +25,14 @@ from nsiqcppstyle_rulemanager import *
 
 
 def RunRule(lexer, line, lineno):
+    t = lexer.GetCurToken()
+
+    # Skip comment lines
+    if (t.type in ["COMMENT", "CPPCOMMENT"]):
+        next_token = lexer.GetNextTokenSkipWhiteSpaceAndComment()
+        if next_token.lineno != t.lineno:
+            return
+
     if not Match(r"^\s*$", line):
         if Search("^ ", line):
             nsiqcppstyle_reporter.Error(DummyToken(

--- a/rules/RULE_4_1_A_B_use_space_for_indentation.py
+++ b/rules/RULE_4_1_A_B_use_space_for_indentation.py
@@ -1,6 +1,6 @@
 """
 Use spaces for indentation.
-This rule check if the each line starts with tabs.
+This rule ensures that each line starts with spaces.
 In addition, it suppresses the violation when the line contains only spaces and tabs.
 
 == Violation ==
@@ -28,6 +28,14 @@ from nsiqcppstyle_types import *
 
 
 def RunRule(lexer: Lexer, line: LineText, lineno: LineNumber) -> None:
+    t = lexer.GetCurToken()
+
+    # Skip comment lines
+    if (t.type in ["COMMENT", "CPPCOMMENT"]):
+        next_token = lexer.GetNextTokenSkipWhiteSpaceAndComment()
+        if next_token.lineno != t.lineno:
+            return
+
     if not Match(r"^\s*$", line):
         if Search("^\t", line):
             nsiqcppstyle_reporter.Error(DummyToken(
@@ -61,6 +69,18 @@ class K {
     def test3(self):
         self.Analyze("test/thisFile.c",
                      """
+class K {
+
+Hello
+}""")
+        self.ExpectSuccess(__name__)
+
+    def test4(self):
+        self.Analyze("test/thisFile.c",
+                     """
+ /**
+\t* Check for Doxygen Comment. This rule doesn't care about doxygen comment block.
+  */
 class K {
 
 Hello

--- a/rules/RULE_4_2_A_A_space_around_operator.py
+++ b/rules/RULE_4_2_A_A_space_around_operator.py
@@ -54,8 +54,8 @@ operator = (
     'RSHIFTEQUAL',
     'ANDEQUAL',
     'XOREQUAL',
-    'OREQUAL'
-
+    'OREQUAL',
+    'SPACESHIP'
 )
 
 nextoperator = (
@@ -248,3 +248,31 @@ wewe
 
 """)
         self.ExpectSuccess(__name__)
+
+    def testSpaceshipOperatorOK(self):
+        self.Analyze("test/thisFile.c",
+                     """
+const bool isEq = std::is_eq(a <=> b);
+""")
+        self.ExpectSuccess(__name__)
+
+    def testSpaceshipOperatorKOLeft(self):
+        self.Analyze("test/thisFile.c",
+                     """
+const bool isEq = std::is_eq(a<=> b);
+""")
+        self.ExpectError(__name__)
+
+    def testSpaceshipOperatorKORight(self):
+        self.Analyze("test/thisFile.c",
+                     """
+const bool isEq = std::is_eq(a <=>b);
+""")
+        self.ExpectError(__name__)
+
+    def testSpaceshipOperatorKOBoth(self):
+        self.Analyze("test/thisFile.c",
+                     """
+const bool isEq = std::is_eq(a<=>b);
+""")
+        self.ExpectError(__name__)

--- a/updateagent/agent.py
+++ b/updateagent/agent.py
@@ -134,8 +134,9 @@ class Version:
         # from the parsed tuple -- so I just store the string here for
         # use by __str__
         self.vstring = vstring
-        components = filter(lambda x: x and x != '.',
-                            self.component_re.split(vstring))
+        components = list(filter(lambda x: x and x != '.',
+                                 self.component_re.split(vstring)))
+
         for i in range(len(components)):
             try:
                 components[i] = int(components[i])
@@ -155,3 +156,6 @@ class Version:
             other = Version(other)
 
         return CmpObjects(self.version, other.version)
+
+    def __lt__(self, other):
+        return self.__cmp__(other) < 0


### PR DESCRIPTION
The new operator, also known as the [spaceship operator](https://en.cppreference.com/w/cpp/language/punctuators#.3C.3D.3E_.28since_C.2B.2B20.29), was introduced in the C++20 standard.

The NSIQ parser now handles it properly.

---

I fixed some tests as well in this PR and added a GitHub Action to ensure this is performed for each PR from now on.
I greatly encourage you to enforce Checks on PR merge, this can be found in the branch protection settings : 
![image](https://github.com/kunaltyagi/nsiqcppstyle/assets/11090416/1f6b7574-fc9e-4ded-a698-2b0113509694)
