### PR TITLE
Remove support for python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4.1.0
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,12 +64,12 @@ cov-report = [
 cov = ["test-cov", "cov-report"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.hatch.envs.lint]
 extra-dependencies = ["black>=23.9.0", "mypy>=1.5.0", "ruff>=0.0.290"]
 features = ["test"]
-python = "3.8"
+python = "3.9"
 [tool.hatch.envs.lint.scripts]
 typing_all = "mypy --install-types --non-interactive --check-untyped-defs {args:.}"
 typing = "mypy --install-types --non-interactive {args:.}"
@@ -91,7 +91,7 @@ all = ["style", "typing"]
 # mypy-args = ["--no-warn-unused-ignores"]
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py39"]
 line-length = 120
 skip-string-normalization = true
 extend-exclude = """
@@ -99,7 +99,7 @@ temp/
 """
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 select = [
   "A",


### PR DESCRIPTION
Python 3.8 EOL on 2024-Oct-07 as per https://devguide.python.org/versions/
